### PR TITLE
support for React 16 - prop-types as separate package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/azazdeaz/transhand",
   "dependencies": {
     "lodash": "^3.8.0",
-    "shallow-equals": "0.0.0"
+    "shallow-equals": "0.0.0",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel": "^5.4.3",

--- a/src/CSSTranshand.jsx
+++ b/src/CSSTranshand.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Transhand from './Transhand'
 import CSSCoordinator from './CSSCoordinator'
 import isElement from 'lodash/lang/isElement'

--- a/src/Transhand.jsx
+++ b/src/Transhand.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import clone from 'lodash/lang/clone'
 import cloneDeep from 'lodash/lang/cloneDeep'
 import assign from 'lodash/object/assign'
@@ -36,15 +37,15 @@ export default class Transhand extends React.Component {
       globalToLocal: PropTypes.func.isRequired,
     }),
     stroke: PropTypes.object,
-    DesignComponent: React.PropTypes.func,
-    hitns: React.PropTypes.object,
-    CursorHintDesignComponent: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    onClick: React.PropTypes.func,
-    onStartDrag: React.PropTypes.func,
-    onEndDrag: React.PropTypes.func,
-    grabEvent: React.PropTypes.any,
-    cursor: React.PropTypes.object,
+    DesignComponent:PropTypes.func,
+    hitns:PropTypes.object,
+    CursorHintDesignComponent:PropTypes.func,
+    onChange:PropTypes.func,
+    onClick:PropTypes.func,
+    onStartDrag:PropTypes.func,
+    onEndDrag:PropTypes.func,
+    grabEvent:PropTypes.any,
+    cursor:PropTypes.object,
   }
 
   static defaultProps = {


### PR DESCRIPTION
To remove  deprecation warnings - extracted React.PropTypes into their own packages.